### PR TITLE
dashify protocol handler for dash: uri

### DIFF
--- a/src/js/services/openURL.js
+++ b/src/js/services/openURL.js
@@ -122,7 +122,7 @@ angular.module('copayApp.services').factory('openURLService', function($rootScop
 
       if (navigator.registerProtocolHandler) {
         $log.debug('Registering Browser handlers base:' + base);
-        navigator.registerProtocolHandler('bitcoin', url, 'Copay Bitcoin Handler');
+        navigator.registerProtocolHandler('dash', url, 'Copay Bitcoin Handler');
         navigator.registerProtocolHandler('web+copay', url, 'Copay Wallet Handler');
       }
     }


### PR DESCRIPTION
copay-dash still registers the bitcoin uri handler. This change will allow to open dash: uris on Android and hopefully other operating systems as well