### PR TITLE
dashify protocol handler for dash: uri

### DIFF
--- a/src/js/services/openURL.js
+++ b/src/js/services/openURL.js
@@ -4,8 +4,8 @@ angular.module('copayApp.services').factory('openURLService', function($rootScop
   var root = {};
 
   root.registeredUriHandlers = [{
-    name: 'Bitcoin BIP21 URL',
-    startsWith: 'bitcoin:',
+    name: 'DASH BIP21 URL',
+    startsWith: 'dash:',
     transitionTo: 'uripayment',
   }, {
     name: 'Glidera Authentication Callback',
@@ -122,7 +122,7 @@ angular.module('copayApp.services').factory('openURLService', function($rootScop
 
       if (navigator.registerProtocolHandler) {
         $log.debug('Registering Browser handlers base:' + base);
-        navigator.registerProtocolHandler('dash', url, 'Copay DASH Handler');
+        navigator.registerProtocolHandler('web+dash', url, 'Copay DASH Handler');
         navigator.registerProtocolHandler('web+copay', url, 'Copay Wallet Handler');
       }
     }

--- a/src/js/services/openURL.js
+++ b/src/js/services/openURL.js
@@ -95,10 +95,10 @@ angular.module('copayApp.services').factory('openURLService', function($rootScop
 
       // This event is sent to an existent instance of Copay (only for standalone apps)
       gui.App.on('open', function(pathData) {
-        if (pathData.indexOf('bitcoin:') != -1) {
-          $log.debug('Bitcoin URL found');
+        if (pathData.indexOf('dash:') != -1) {
+          $log.debug('DASH URL found');
           handleOpenURL({
-            url: pathData.substring(pathData.indexOf('bitcoin:'))
+            url: pathData.substring(pathData.indexOf('dash:'))
           });
         } else if (pathData.indexOf('copay:') != -1) {
           $log.debug('Copay URL found');
@@ -122,7 +122,7 @@ angular.module('copayApp.services').factory('openURLService', function($rootScop
 
       if (navigator.registerProtocolHandler) {
         $log.debug('Registering Browser handlers base:' + base);
-        navigator.registerProtocolHandler('dash', url, 'Copay Bitcoin Handler');
+        navigator.registerProtocolHandler('dash', url, 'Copay DASH Handler');
         navigator.registerProtocolHandler('web+copay', url, 'Copay Wallet Handler');
       }
     }

--- a/src/js/services/openURL.js
+++ b/src/js/services/openURL.js
@@ -122,7 +122,7 @@ angular.module('copayApp.services').factory('openURLService', function($rootScop
 
       if (navigator.registerProtocolHandler) {
         $log.debug('Registering Browser handlers base:' + base);
-        navigator.registerProtocolHandler('bitcoin', url, 'Copay Bitcoin Handler');
+        navigator.registerProtocolHandler('dash', url, 'Copay Bitcoin Handler');
         navigator.registerProtocolHandler('web+copay', url, 'Copay Wallet Handler');
       }
     }


### PR DESCRIPTION
copay-dash still registers the bitcoin uri handler. This change will allow to open dash: uris on Android and hopefully other operating systems as well.

Unfortunately it seems we can't just register the protocol handler 'dash:' using the method Navigator.registerProtocolHandler(), because 'dash:' as opposed to 'bitcoin:' is not a whitelisted and permitted url scheme to register with that method (see: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler). Rather, sticking with the Navigator.registerProtocolHandler() method for the moment, we have to use 'web+dash:'. Will need some testing if this will actually works also for links with 'dash:' instead of 'web+dash:'.