### PR TITLE
dashify protocol handler for dash: uri

### DIFF
--- a/src/js/services/openURL.js
+++ b/src/js/services/openURL.js
@@ -122,7 +122,7 @@ angular.module('copayApp.services').factory('openURLService', function($rootScop
 
       if (navigator.registerProtocolHandler) {
         $log.debug('Registering Browser handlers base:' + base);
-        navigator.registerProtocolHandler('bitcoin', url, 'Copay Bitcoin Handler');
+        navigator.registerProtocolHandler('web+dash', url, 'Copay Dash Handler');
         navigator.registerProtocolHandler('web+copay', url, 'Copay Wallet Handler');
       }
     }


### PR DESCRIPTION
copay-dash still registers the bitcoin uri handler. This change will allow to open dash: uris on Android and hopefully other operating systems as well.

Unfortunately it seems we can't just register the protocol handler 'dash:' using the method Navigator.registerProtocolHandler(), because 'dash:' as opposed to 'bitcoin:' is not a whitelisted and permitted url scheme to register with that method (see: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler). Rather, sticking with the Navigator.registerProtocolHandler() method for the moment, we have to use 'web+dash:'. Will need some testing if this will actually work also for links with 'dash:' instead of 'web+dash:'.